### PR TITLE
Add empty Gopkg.toml to resolve dep complaints

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -64,6 +64,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "48216b52bb650ccf6fa948b13908626909a40cd519eeefbd59559f9dddf16cb7"
+  inputs-digest = "66a89abcc4db7160ad4b91ca6c16049a616004060b3c42d4a13a8d98f5838d90"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
Otherwise `dep` says this:

```
dep status
could not find project Gopkg.toml, use dep init to initiate a manifest
```

Closes #6.