### PR TITLE
Add ClickHouse http client timeout

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 	"unicode"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -73,6 +74,7 @@ func NewExporter(uri url.URL, insecure bool, user, password string) *Exporter {
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
 			},
+			Timeout: 30 * time.Second,
 		},
 		user:     user,
 		password: password,


### PR DESCRIPTION
30 seconds for each request is long enough for ClickHouse to
respond under any conditions, but short enough to close stuck
connections.

Making it configurable means breaking `NewExporter` clients.
Or, a new interface for creating exporters has to be created.

Closes #25 which is most likely caused by
https://github.com/yandex/ClickHouse/issues/4060.