### PR TITLE
Replace hyphens in metric names with underscores

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -320,7 +320,9 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 func metricName(in string) string {
 	out := toSnake(in)
-	return strings.Replace(out, ".", "_", -1)
+	out = strings.Replace(out, ".", "_", -1)
+	out = strings.Replace(out, "-", "_", -1)
+	return out
 }
 
 // toSnake convert the given string to snake case following the Golang format:

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -62,3 +62,22 @@ func TestParseNumber(t *testing.T) {
 		}
 	}
 }
+
+func TestMetricName(t *testing.T) {
+	type testCase struct {
+		in  string
+		out string
+	}
+
+	testCases := []testCase{
+		{in: "foo.bar", out: "foo_bar"},
+		{in: "foo-bar", out: "foo_bar"},
+	}
+
+	for _, tc := range testCases {
+		out := metricName(tc.in)
+		if out != tc.out {
+			t.Fatalf("wrong output: %s, expected %s", out, tc.out)
+		}
+	}
+}


### PR DESCRIPTION
Hi,

the exporter might generate metric names with hyphens which causes prometheus scrape to crash with `invalid metric type "0 gauge"`.

Example:

```
# HELP clickhouse_block_write_merges_rbd0 Number of BlockWriteMerges_rbd0 async processed
# TYPE clickhouse_block_write_merges_rbd0 gauge
clickhouse_block_write_merges_rbd0 0
```

This commit fixes the issue and tests previously untested code.